### PR TITLE
[advc-30] Modifica admin.js pra suportar selected

### DIFF
--- a/assets/scripts/admin.js
+++ b/assets/scripts/admin.js
@@ -5,8 +5,13 @@
         return function(props) {
             // if(props.slug === 'xtt-pa-format' || props.slug === 'xtt-pa-regiao' || props.slug === 'xtt-pa-press-type')
 
-            if(props.slug === 'xtt-pa-owner' || props.slug === 'xtt-pa-press-type' || props.slug === 'xtt-pa-format')
-                return el(window.DropdownTermSelector, { ...props });
+            if(props.slug === 'xtt-pa-owner' || props.slug === 'xtt-pa-press-type' || props.slug === 'xtt-pa-format') {
+                let newprops = {...props};
+                if(props.slug === 'xtt-pa-format')
+                    newprops.selected = 'noticia';
+
+                return el(window.DropdownTermSelector, newprops);
+            }
 
             return el(OriginalComponent, { ...props });
         };

--- a/assets/scss/admin-metabox.scss
+++ b/assets/scss/admin-metabox.scss
@@ -1,6 +1,6 @@
-#editor .postbox.acf-postbox.show{
+#editor .edit-post-layout__metaboxes .postbox.acf-postbox.show{
   display: block !important;
 }
-#editor .postbox.acf-postbox{
+#editor .edit-post-layout__metaboxes .postbox.acf-postbox{
   display: none !important;
 }


### PR DESCRIPTION
[advc-30] Modifica o arquivo admin.js para que os campos select de taxonomy suportem o atributo selected e corrige problema com campo metabox